### PR TITLE
fix issue #34 - disable depguard linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,8 @@ linters:
   - wastedassign
   # Disable due to mock private functions
   - testpackage
+  # Disable due to use of non-standard packages
+  - depguard
 
 linters-settings:
   cyclop:


### PR DESCRIPTION
- Disable depguard from the golangci-lint due to the use of external (non-standard) packages.